### PR TITLE
Lock locale of headless Chrome to en-GB

### DIFF
--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -47,7 +47,8 @@ abstract class DuskTestCase extends BaseTestCase
     {
         $options = (new ChromeOptions)->addArguments([
             '--disable-gpu',
-            '--headless'
+            '--headless',
+            '--lang=en-GB'
         ]);
 
         $driver = RemoteWebDriver::create(


### PR DESCRIPTION
This PR sets the locale of the headless Chrome instance used for Laravel Dusk testing to `en-GB`. The default appears to be `en-US`.

This fixes inconsistent test results with Dusk tests that interact with `date` type `input` fields.