### PR TITLE
Force chrome version to be latest stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     packages:
     - mysql-server
     - mysql-client
+  chrome: stable
 
 cache:
   directories:


### PR DESCRIPTION
We've noticed an issue where Travis CI does not spin up with a consistent chrome version for whatever reason, forcing it to install the latest stable version resolved this issue.