### PR TITLE
Ensure logs endpoint relies on config rather than the environment

### DIFF
--- a/app/Providers/LogViewerRouteProvider.php
+++ b/app/Providers/LogViewerRouteProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Rap2hpoutre\LaravelLogViewer\LogViewerController;
+use Route;
+
+class LogViewerRouteProvider extends ServiceProvider
+{
+    /**
+     * Register the log viewer route, if the appropriate access credentials have been set in the app configuration.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        ['username' => $username, 'password' => $password] = config('laravel-route-restrictor.logs');
+
+        if ($username === null || $password === null) {
+            return;
+        }
+
+        Route::get('/logs', [LogViewerController::class, 'index'])
+             ->middleware("routeRestrictor:$username,$password");
+    }
+}

--- a/app/Providers/LogViewerRouteProvider.php
+++ b/app/Providers/LogViewerRouteProvider.php
@@ -17,7 +17,7 @@ class LogViewerRouteProvider extends ServiceProvider
     {
         ['username' => $username, 'password' => $password] = config('laravel-route-restrictor.logs');
 
-        if ($username === null || $password === null) {
+        if (empty($username) || empty($password)) {
             return;
         }
 

--- a/config/app.php
+++ b/config/app.php
@@ -160,6 +160,7 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        App\Providers\LogViewerRouteProvider::class,
 
     ],
 

--- a/config/laravel-route-restrictor.php
+++ b/config/laravel-route-restrictor.php
@@ -9,6 +9,11 @@ return [
     'global' => [
         'username' => env('ROUTE_RESTRICTOR_GLOBAL_USERNAME', null),
         'password' => env('ROUTE_RESTRICTOR_GLOBAL_PASSWORD', null)
-    ]
+    ],
+
+    'logs' => [
+        'username' => env('LOGS_USERNAME'),
+        'password' => env('LOGS_PASSWORD')
+    ],
 
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,9 +16,13 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::group(['middleware' => 'routeRestrictor:'.env('LOGS_USERNAME').','.env('LOGS_PASSWORD')], function () {
-    Route::get('/logs', '\Rap2hpoutre\LaravelLogViewer\LogViewerController@index');
-});
+
+['username' => $logsUsername, 'password' => $logsPassword] = config('laravel-route-restrictor.logs');
+if ($logsUsername && $logsPassword) {
+    Route::group(['middleware' => "routeRestrictor:$logsUsername,$logsPassword"], function () {
+        Route::get('/logs', '\Rap2hpoutre\LaravelLogViewer\LogViewerController@index');
+    });
+}
 
 Auth::routes();
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,17 +11,9 @@
 |
 */
 
-
 Route::get('/', function () {
     return view('welcome');
 });
-
-['username' => $logsUsername, 'password' => $logsPassword] = config('laravel-route-restrictor.logs');
-if ($logsUsername && $logsPassword) {
-    Route::group(['middleware' => "routeRestrictor:$logsUsername,$logsPassword"], function () {
-        Route::get('/logs', '\Rap2hpoutre\LaravelLogViewer\LogViewerController@index');
-    });
-}
 
 Auth::routes();
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,6 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-
 ['username' => $logsUsername, 'password' => $logsPassword] = config('laravel-route-restrictor.logs');
 if ($logsUsername && $logsPassword) {
     Route::group(['middleware' => "routeRestrictor:$logsUsername,$logsPassword"], function () {


### PR DESCRIPTION
This fixes a potential vulnerability:
In the event that the application config were ever cached, calls to
env() return null.
This would mean the logs route would not have a username and password
restriction set, and could be accessed without any authentication.

In addition, this ensures that if either the username or password are
null, the logs endpoint is not registered.