### PR TITLE
Hide environment variable values on exception pages.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 indent_style = space
-indent_size = 2
+indent_size = 4
 trim_trailing_whitespace = true
 
 [*.md]

--- a/config/app.php
+++ b/config/app.php
@@ -255,6 +255,7 @@ return [
 
         '_POST' => [
             'password',
+            'password_confirmation',
         ],
     ],
 

--- a/config/app.php
+++ b/config/app.php
@@ -213,4 +213,45 @@ return [
 
     ],
 
+    /*
+     |--------------------------------------------------------------------------
+     | Debug Blacklist
+     |--------------------------------------------------------------------------
+     |
+     | Hide environment variable values from the exception page.
+     |
+     */
+
+    'debug_blacklist' => [
+        '_ENV' => [
+            'APP_KEY',
+            'DB_DATABASE',
+            'DB_USERNAME',
+            'DB_PASSWORD',
+            'REDIS_PASSWORD',
+            'REDIS_PORT',
+            'MAIL_USERNAME',
+            'MAIL_PASSWORD',
+            'LOGS_USERNAME',
+            'LOGS_PASSWORD',
+        ],
+
+        '_SERVER' => [
+            'APP_KEY',
+            'DB_DATABASE',
+            'DB_USERNAME',
+            'DB_PASSWORD',
+            'REDIS_PASSWORD',
+            'REDIS_PORT',
+            'MAIL_USERNAME',
+            'MAIL_PASSWORD',
+            'LOGS_USERNAME',
+            'LOGS_PASSWORD',
+        ],
+
+        '_POST' => [
+            'password',
+        ],
+    ],
+
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -234,6 +234,8 @@ return [
             'MAIL_PASSWORD',
             'LOGS_USERNAME',
             'LOGS_PASSWORD',
+            'AWS_ACCESS_KEY_ID',
+            'AWS_SECRET_ACCESS_KEY',
         ],
 
         '_SERVER' => [
@@ -247,6 +249,8 @@ return [
             'MAIL_PASSWORD',
             'LOGS_USERNAME',
             'LOGS_PASSWORD',
+            'AWS_ACCESS_KEY_ID',
+            'AWS_SECRET_ACCESS_KEY',
         ],
 
         '_POST' => [


### PR DESCRIPTION
I noticed on one of our projects that we weren't blacklisting environment variables and thought this would be beneficial to add to the boilerplate. This was added in Laravel 5.7.

* Adds `debug_blacklist` to the `config/app.php` file to hide environment variable values on debug pages, preventing any leak of the appropriate keys. This should be modified on a per-project basis to ensure API keys are covered. It replaces the values with asterisks.
* Changes `.editorconfig` to match our internal style guide for indenting.