### PR TITLE
Update Travis config to use Ubuntu Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,15 @@ language: php
 sudo: required
 
 php:
-- 7.2
+- "7.2"
 
-dist: trusty
+dist: xenial
 
 services:
 - mysql
 
 addons:
   apt:
-    sources:
-    - mysql-5.7-trusty
     packages:
     - mysql-server
     - mysql-client
@@ -32,7 +30,6 @@ before_script:
 - yes | pecl install imagick
 # Setup headless web browser for Laravel Dusk tests
 - export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 - ./vendor/laravel/dusk/bin/chromedriver-linux &
 # Install Composer dependencies
 - composer install --no-interaction


### PR DESCRIPTION
Currently the boilerplate uses Ubuntu 14.04 (trusty) for Travis CI instances.

This PR updates the Travis configuration to use Ubuntu 16.04 (xenial), which offers significantly better performance, and removes the need to use a separate MySQL repository for MySQL 5.7.