### PR TITLE
Use the latest stable Chrome driver instead of 74.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
 # Install Composer dependencies
 - composer install --no-interaction
 # Setup headless web browser for Laravel Dusk tests
-- php artisan dusk:chrome-driver 74
+- php artisan dusk:chrome-driver
 - export DISPLAY=:99.0
 - ./vendor/laravel/dusk/bin/chromedriver-linux &
 # Create database, migrate & seed


### PR DESCRIPTION
Travis CI builds currently [fail](https://travis-ci.org/jameswilddev/laravel-boilerplate/builds/566379227) as .travis.yml specifies that the [latest stable Chrome is installed](https://github.com/langleyfoxall/laravel-boilerplate/blob/ad094c48eeab6aba1f99cd1e11cc156533155c81/.travis.yml#L18), but also that a [Chrome driver only compatible with Chrome 74 is installed](https://github.com/langleyfoxall/laravel-boilerplate/blob/ad094c48eeab6aba1f99cd1e11cc156533155c81/.travis.yml#L34).  Unfortunately, [it does not seem that there is a way to specify exactly which Chrome version Travis CI installs](https://travis-ci.community/t/ability-to-fix-chrome-version/2651).

As a workaround, I've changed the instruction to install the Chrome driver, to install the latest stable version.  This should *usually* match up with the latest Chrome version, and if it does not, should eventually "catch up", whereas a hard-coded Chrome driver version will never "heal" once a new stable version of Chrome is released.