### PR TITLE
Update .editorconfig to match laravel/laravel

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,12 +5,11 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 indent_style = space
-indent_size = 2
+indent_size = 4
 trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
 
 [*.yml]
-indent_style = space
 indent_size = 2


### PR DESCRIPTION
Due to a recent update in PHPStorm, it was brought to our attention that the .editorconfig contained within the laravel/laravel repository was different to the boilerplate. This PR simply updates our boilerplate to match, and allows PHPStorm to correctly indent PHP while abiding by the files rules.